### PR TITLE
Fix hosting perk & killingfloor server on same machine

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -108,7 +108,7 @@ namespace KFServerPerks
 
         private static void SendMessage(IPEndPoint endpoint, ENetID type, string message = "")
         {
-            if (IPAddress.IsLoopback(endpoint.Address) || endpoint.Address.Address == 0)
+            if (endpoint.Address.Equals(0))
                 return;
 
             byte[] msgarr = Encoding.ASCII.GetBytes(message);


### PR DESCRIPTION
https://stackoverflow.com/questions/29374219/why-does-ipaddress-isloopback-return-true-for-an-entire-range-of-ipv4-addresses

The IsLoopback check was preventing the Perks application from responding to a Killingfloor server's requests when running on the same machine. Not sure of a time when this check is required. Tested using both Windows and Linux.